### PR TITLE
Parse empty responses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,12 +49,14 @@ module.exports = function jsonRequest (options, data, callback) {
 
     return tinyreq(options, (err, body, res) => {
         if (err) {
-            return callback(err);
+            return callback(err, body, res);
         }
-        try {
-            body = JSON.parse(body);
-        } catch (e) {
-            return callback(e);
+        if (body) {
+            try {
+                body = JSON.parse(body);
+            } catch (e) {
+                return callback(e, body, res);
+            }
         }
         callback(null, body, res);
     });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:IonicaBizau/node-jsonrequest.git"
+    "url": "git@github.com:IonicaBizau/jsonrequest.git"
   },
   "keywords": [
     "json",
@@ -18,9 +18,9 @@
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/IonicaBizau/node-jsonrequest/issues"
+    "url": "https://github.com/IonicaBizau/jsonrequest/issues"
   },
-  "homepage": "https://github.com/IonicaBizau/node-jsonrequest",
+  "homepage": "https://github.com/IonicaBizau/jsonrequest",
   "directories": {
     "example": "example",
     "test": "test"

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,9 @@ server.addPage("/hello", function (lien) {
       , data: lien.data
     });
 });
+server.addPage("/empty", function (lien) {
+    lien.end("");
+});
 
 
 server.on("load", function (err) {
@@ -72,6 +75,14 @@ it("should support get method and https protocol", function (cb) {
     JsonRequest("https://status.github.com/api.json", function (err, data) {
         Assert.equal(err, null);
         Assert.equal(data.constructor === Object, true);
+        cb();
+    });
+});
+
+it("should parse empty responses successfully", function (cb) {
+    JsonRequest("http://localhost:9000/empty", function (err, data) {
+        Assert.equal(err, null);
+        Assert.equal(data, "");
         cb();
     });
 });


### PR DESCRIPTION
Don't throw errors if the response is empty.